### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -30,17 +30,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageVersion Include="Zonit.Extensions.Cultures.Abstractions" Version="0.1.5" />
-    <PackageVersion Include="Zonit.Extensions.Organizations.Abstractions" Version="0.1.8" />
-    <PackageVersion Include="Zonit.Extensions.Identity.Abstractions" Version="0.1.6" />
-    <PackageVersion Include="Zonit.Extensions.Projects.Abstractions" Version="0.1.4" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="..\..\Readme.md" Pack="true" PackagePath="" Visible="false" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Include="Diacritics" Version="4.0.17" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Diacritics" Version="4.0.17" />

--- a/Tools/Update-DotNet.ps1
+++ b/Tools/Update-DotNet.ps1
@@ -151,7 +151,8 @@ function Get-BestPackageVersion {
         $followsDotNetVersioning = $PackageId -match '^Microsoft\.(Extensions|AspNetCore|EntityFrameworkCore|JSInterop)\.'
         
         if ($followsDotNetVersioning) {
-            # First try: exact major version match
+            # Strategy: Try to find version with Major <= targetMajor
+            # First try: exact major version match (preferred)
             if ($AllowPrerelease) {
                 $best = $allVersions | Where-Object { 
                     $_.Version.Major -eq $targetMajor 
@@ -162,15 +163,15 @@ function Get-BestPackageVersion {
                 } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
             }
             
-            # Second try: if no exact match, try one major version lower
-            if (-not $best -and $targetMajor -gt 1) {
+            # Second try: if no exact match, find highest version where Major <= targetMajor
+            if (-not $best) {
                 if ($AllowPrerelease) {
                     $best = $allVersions | Where-Object { 
-                        $_.Version.Major -eq ($targetMajor - 1) 
+                        $_.Version.Major -le $targetMajor 
                     } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
                 } else {
                     $best = $allVersions | Where-Object { 
-                        $_.Version.Major -eq ($targetMajor - 1) -and -not $_.IsPrerelease 
+                        $_.Version.Major -le $targetMajor -and -not $_.IsPrerelease 
                     } | Sort-Object -Property @{Expression={$_.Version}; Descending=$true} | Select-Object -First 1
                 }
             }
@@ -230,9 +231,14 @@ foreach ($proj in $csprojs) {
         
         $pg = $propertyGroups[0]
         
+        # Check if TargetFramework or TargetFrameworks exists
+        $tfNodes = @($pg.SelectNodes("TargetFramework"))
+        $tfsNodes = @($pg.SelectNodes("TargetFrameworks"))
+        $hasTargetFramework = ($tfNodes.Count -gt 0) -or ($tfsNodes.Count -gt 0)
+        
         # Remove both singular and plural variants
-        @($pg.SelectNodes("TargetFramework")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
-        @($pg.SelectNodes("TargetFrameworks")) | ForEach-Object { $pg.RemoveChild($_) | Out-Null }
+        foreach ($node in $tfNodes) { $pg.RemoveChild($node) | Out-Null }
+        foreach ($node in $tfsNodes) { $pg.RemoveChild($node) | Out-Null }
         
         # Add correct element name
         $tfNode = $xml.CreateElement($elementName)
@@ -240,7 +246,12 @@ foreach ($proj in $csprojs) {
         $pg.AppendChild($tfNode) | Out-Null
         
         $xml.Save($proj.FullName)
-        Write-Host "  [OK] $($proj.Name): Set to $targetFrameworksString" -ForegroundColor Green
+        
+        if ($hasTargetFramework) {
+            Write-Host "  [OK] $($proj.Name): Updated to $targetFrameworksString" -ForegroundColor Green
+        } else {
+            Write-Host "  [OK] $($proj.Name): Added $targetFrameworksString" -ForegroundColor Cyan
+        }
     } catch {
         Write-Warning "  [FAIL] Failed to update $($proj.Name): $_"
     }
@@ -289,7 +300,40 @@ foreach ($proj in $csprojs) {
 }
 
 $packageList = $allPackages.Keys | Sort-Object
-Write-Host "  Found $($packageList.Count) unique packages" -ForegroundColor Cyan
+Write-Host "  Found $($packageList.Count) unique packages across all projects" -ForegroundColor Cyan
+
+# Also collect packages from existing Directory.Packages.props for comparison
+$existingPackages = @{}
+if ($propsFile) {
+    try {
+        [xml]$existingXml = Get-Content $propsFile.FullName
+        $existingItemGroups = @($existingXml.Project.ItemGroup)
+        foreach ($ig in $existingItemGroups) {
+            foreach ($pv in $ig.PackageVersion) {
+                if ($pv.Include) {
+                    $existingPackages[$pv.Include] = $true
+                }
+            }
+        }
+    } catch {
+        Write-Verbose "Could not read existing packages from Directory.Packages.props"
+    }
+}
+
+# Check for packages that will be removed (not in any .csproj anymore)
+$packagesToRemove = @()
+foreach ($pkg in $existingPackages.Keys) {
+    if (-not $allPackages.ContainsKey($pkg)) {
+        $packagesToRemove += $pkg
+    }
+}
+
+if ($packagesToRemove.Count -gt 0) {
+    Write-Host "  Packages no longer referenced (will be removed): $($packagesToRemove.Count)" -ForegroundColor Yellow
+    foreach ($pkg in $packagesToRemove) {
+        Write-Host "    - $pkg" -ForegroundColor DarkYellow
+    }
+}
 
 # ============================================================================
 # STEP 4: Update Directory.Packages.props
@@ -380,17 +424,23 @@ try {
     
     # Remove ONLY conditional ItemGroups that match our target frameworks
     # This allows us to recreate them with updated package versions
-    # PRESERVE unconditional ItemGroups (common packages without conditions)
+    # ALSO remove unconditional ItemGroups to prevent duplicates
     foreach ($ig in $existingItemGroups) {
         $shouldRemove = $false
         
-        if ($ig.PackageVersion -and $ig.Condition) {
-            # Check if this ItemGroup's condition matches any of our target frameworks
-            foreach ($tf in $TargetFrameworks) {
-                if ($ig.Condition -match [regex]::Escape($tf)) {
-                    $shouldRemove = $true
-                    break
+        if ($ig.PackageVersion) {
+            if ($ig.Condition) {
+                # Check if this ItemGroup's condition matches any of our target frameworks
+                foreach ($tf in $TargetFrameworks) {
+                    if ($ig.Condition -match [regex]::Escape($tf)) {
+                        $shouldRemove = $true
+                        break
+                    }
                 }
+            } else {
+                # Remove unconditional ItemGroups with PackageVersion to prevent duplicates
+                # We'll recreate all packages in conditional groups per framework
+                $shouldRemove = $true
             }
         }
         

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -4,54 +4,17 @@
     "net9.0",
     "net10.0"
   ],
+  "ProjectsFound": 6,
+  "PackagesFound": 7,
+  "ChangeSummaryText": "No package version changes - this might be a new setup or no updates available",
+  "Timestamp": "2025-11-17 02:40:58",
+  "PackageChanges": [],
   "Summary": {
     "FrameworksSet": "net8.0;net9.0;net10.0",
-    "PackagesConfigured": 7,
     "FrameworkSpecificGroups": 3,
     "DirectoryPackagesPropsUpdated": true,
-    "ProjectsUpdated": 6,
-    "PackagesChanged": 6
-  },
-  "PackageChanges": [
-    {
-      "Package": "Zonit.Extensions.Cultures",
-      "Framework": "net8.0",
-      "OldVersion": "(new)",
-      "NewVersion": "0.1.7"
-    },
-    {
-      "Package": "Zonit.Extensions.Cultures.Abstractions",
-      "Framework": "net8.0",
-      "OldVersion": "0.1.5",
-      "NewVersion": "0.1.7"
-    },
-    {
-      "Package": "Zonit.Extensions.Cultures",
-      "Framework": "net9.0",
-      "OldVersion": "(new)",
-      "NewVersion": "0.1.7"
-    },
-    {
-      "Package": "Zonit.Extensions.Cultures.Abstractions",
-      "Framework": "net9.0",
-      "OldVersion": "0.1.5",
-      "NewVersion": "0.1.7"
-    },
-    {
-      "Package": "Zonit.Extensions.Cultures",
-      "Framework": "net10.0",
-      "OldVersion": "(new)",
-      "NewVersion": "0.1.7"
-    },
-    {
-      "Package": "Zonit.Extensions.Cultures.Abstractions",
-      "Framework": "net10.0",
-      "OldVersion": "0.1.5",
-      "NewVersion": "0.1.7"
-    }
-  ],
-  "Timestamp": "2025-11-17 02:09:29",
-  "PackagesFound": 7,
-  "ChangeSummaryText": "Zonit.Extensions.Cultures : (new) -> 0.1.7\nZonit.Extensions.Cultures.Abstractions : 0.1.5 -> 0.1.7",
-  "ProjectsFound": 6
+    "PackagesChanged": 0,
+    "PackagesConfigured": 7,
+    "ProjectsUpdated": 6
+  }
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/20

---

#### What Changed:
- **Projects Updated:** 6
- **Packages Configured:** 7
- **Package Versions Changed:** 0
- **Common Packages:** COMMON_7
- **Framework-Specific Packages:** 0
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**No package version changes** - packages may have been newly configured

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/20
